### PR TITLE
Update Webhooks Setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ gem 'simplecov', require: false
 gem 'sprockets', '~> 3'
 
 source 'https://gems.weblinc.com' do
-  gem 'workarea-ci'
+  gem 'workarea-ci', '~> 3.3.0'
   gem 'workarea-oms', '~> 5.1.1'
 end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,52 @@
+WebLinc
+Business Source License
+
+Licensor: WebLinc Corporation, 22 S. 3rd Street, 2nd Floor, Philadelphia PA 19106
+
+Licensed Work: Workarea Commerce Platform
+               The Licensed Work is (c) 2019 WebLinc Corporation
+
+Additional Use Grant:
+                      You may make production use of the Licensed Work without an additional license agreement with WebLinc so long as you do not use the Licensed Work for a Commerce Service.
+
+                      A "Commerce Service" is a commercial offering that allows third parties (other than your employees and contractors) to access the functionality of the Licensed Work by creating or managing commerce functionality, the products, taxonomy, assets and/or content of which are controlled by such third parties.
+
+                      For information about obtaining an additional license agreement with WebLinc, contact licensing@workarea.com.
+
+Change Date: 2019-08-20
+
+Change License: Version 2.0 or later of the GNU General Public License as published by the Free Software Foundation
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production use of the Licensed Work. The Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the terms of the Change License, and the rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License, you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this License. This License applies separately for each version of the Licensed Work and the Change Date may vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of the Licensed Work. If you receive the Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License). TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE. MariaDB hereby grants you permission to use this License’s text to license your works and to refer to it using the trademark "Business Source License" as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+In consideration of the right to use this License’s text and the "Business Source License" name and trademark, Licensor covenants to MariaDB, and to all other recipients of the licensed work to be provided by Licensor:
+
+To specify as the Change License the GPL Version 2.0 or any later version, or a license that is compatible with GPL Version 2.0 or a later version, where "compatible" means that software provided under the Change License can be included in a program with software provided under GPL Version 2.0 or a later version. Licensor may specify additional Change Licenses without limitation.
+
+To either: (a) specify an additional grant of rights to use that does not impose any additional restriction on the right granted in this License, as the Additional Use Grant; or (b) insert the text "None."
+
+To specify a Change Date.
+
+Not to modify this License in any other way.
+
+Notice
+The Business Source License (this document, or the "License") is not an Open Source license. However, the Licensed Work will eventually be made available under an Open Source License, as stated in this License.
+
+For more information on the use of the Business Source License generally, please visit the Adopting and Developing Business Source License FAQ.
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved. "Business Source License" is a trademark of MariaDB Corporation Ab.

--- a/README.md
+++ b/README.md
@@ -1,114 +1,197 @@
- Workarea Flow Io
-================================================================================
+# Workarea Flow Io
 
-Flow Io is an international checkout solution.  Clients set up `Experience`s in Flow that target specific currencies
-or regions.  A customer is geolocated using a javascript call, or can opt to change their shipping country via a javascript widget.
-Customers checking out in foreign currencies get redirected to Flow's hosted checkout solution.
-
-Secrets
---------------------------------------------------------------------------------
-    flow_io:
-      api_token:
-      organziation_id:
-      webhook_shared_secret:
-
-Configuration
---------------------------------------------------------------------------------
-
-### Localization Attributes
-
-The plugin provides localization attributes for: `original_price`, `sale_price`, `msrp`, `product_id` and `digital`
-These correspond to values of the `attributes` when exporting an item to flow and come back in the `local_item_pricing` `attributes` field.
-Other fields include `gtin`, `brand`, `hazardous` see https://docs.flow.io/module/localization/resource/attributes and
-https://docs.flow.io/type/attribute-form
-
-### Checkout
-
-All international orders will be routed to a Flow.io hosted checkout page. By default the order confirmation page will hosted with Flow.io as well.
-
-Customers will be redirected to the default Flow.io checkout url. However, most clients will choose to redirect to a subdomain.
-The redirect domain is controlled via the following config:
-
-    config.flow_io.checkout_uri = "https://checkout.flow.io"
+[Flow](https://flow.io) is an international checkout solution.  Clients set up
+an "experience" in Flow that targets specific currencies or regions.  A
+customer is geolocated using a javascript call, or they can opt to change
+their shipping country via a javascript widget.  Customers checking out
+in foreign currencies get redirected to Flow's hosted checkout solution.
 
 ## Installation
 
-    bundle exec rake workarea:flow_io:install
+To install Flow, add it to your Gemfile:
 
-This rake task will just run the following rake tasks in order:
+```ruby
+gem 'workarea-flow_io'
+```
+
+...and run `bundle install`!
+
+Next, configure your credentials in **config/secrets.yml**, as shown here:
+
+```yaml
+flow_io:
+  # get your API token from https://console.flow.io
+  # under 'Organization Settings > Integrations"
+  api_token:
+  organization_id:
+```
+
+Finally, run the generator to set up Flow for use with your application:
+
+    rails workarea:flow_io:install
+
+This task creates localization attributes, webhooks, and exports products
+to Flow for later use, which are broken out into the following Rake
+tasks (run in the same order):
 
     workarea:flow_io:create_localization_attributes
     workarea:flow_io:create_webhooks
     workarea:flow_io:export_products
 
-## Flow under the hood
+Now you're ready to Let It Flow!
+
+## Configuration
+
+Flow is configured using your `Workarea.config`, much like most of our
+other plugins. Many of these settings have defaults provided out of the
+box. The above steps in "Installation" should be the bare minimum you
+need to get the plugin working.
+
+### JavaScript Integration
+
+`Workarea::FlowIo` can optionally use [FlowJS](https://docs-beta.flow.io/docs/flowjs)
+as an additional layer of real-time pricing updates, or as the primary
+means by which "global" experience customers with no pre-defined
+experience can view localized prices. It is off by default, but can be
+enabled by setting the following in an initializer:
+
+```ruby
+Workarea.configure do |config|
+  config.flow_io.enable_javascript = true
+end
+```
+
+### Localization Attributes
+
+The plugin provides localization attributes for: `original_price`,
+`sale_price`, `msrp`, `product_id` and `digital` These correspond to
+values of the `attributes` when exporting an item to flow, and they come back
+in the `local_item_pricing` `attributes` field.  Other fields include
+`gtin`, `brand`, and `hazardous`. For more information, visit
+https://docs.flow.io/module/localization/resource/attributes and
+https://docs.flow.io/type/attribute-form
+
+### Checkout
+
+All international orders will be routed to a Flow.io hosted checkout
+page. By default the order confirmation page will be hosted with Flow.io as
+well.
+
+Customers will be redirected to the default Flow.io checkout url.
+However, most clients will choose to redirect to a subdomain.  The
+redirect domain is controlled via the following config:
+
+
+```ruby
+Workarea.configure do |config|
+  config.flow_io.checkout_uri = 'https://checkout.flow.io'
+end
+```
+
+## Under The Hood
+
+This section explains a bit about how Flow is integrated with your
+Workarea store.
+
 ### Item Exporting / Importing
-A callbacks worker gets enqueued on 'Catalog::Product', `Shipping::Sku`, `Pricing::Sku`, and `Pricing::Price` save.  Depending on the number
-of skus changed, the worker will export the affected items to Flow.  Flow will then create Local Items to represent those skus in each experiece,
-and push those prices back to Workarea.  The plugin embeds those local items on the `Pricing::Sku` for display.  The base price of a localized
-price will not necessarily be the same.  After the initial price is converted into the localized currency, rounding and margin rules are applied
-and then it is converted back into the default currency as the base price.
+
+A callbacks worker gets enqueued on `Catalog::Product`, `Shipping::Sku`,
+`Pricing::Sku`, and `Pricing::Price` save.  Depending on the number of
+skus changed, the worker will export the affected items to Flow.  Flow
+will then create Local Items to represent those skus in each experiece,
+and push those prices back to Workarea.  The plugin embeds those local
+items on the `Pricing::Sku` for display.  The base price of a localized
+price will not necessarily be the same.  After the initial price is
+converted into the localized currency, rounding and margin rules are
+applied and then it is converted back into the default currency as the
+base price.
 
 ### Order Pricing
-When a customer is transacting in a currency other than the default currency, two sets
-of `PriceAdjutment`s are in effect.  The standard `#price_adjutments` on `Order::Item` and
-`Shipping` are used to track pricing in the sites default currency while `#flow_price_adjustments`
+
+When a customer is transacting in a currency other than the default
+currency, two sets of `PriceAdjustment`s are in effect.  The standard
+`#price_adjustments` on `Order::Item` and `Shipping` are used to track
+pricing in the sites default currency while `#flow_price_adjustments`
 will store pricing the customer transacted in.
 
 ### Checkout Flow
-A new pricing calculator is added, `FlowLocalizationCalculator` and appended to the END of the
-pricing calculators array; it is important that if a build adds custom calculators that the
-`FlowLocalizationCalculator` is last.  This calculator sends the order to flow and updates the
-`Order::Item` and `Shipping` `#price_adjutments` with localized prices and updated base prices.
-Because of the way discounting is passed to flow, discounts are displaying as a generic Discount
-adjustment, instead of an adjustment for each discount.  Display will still happen at the order or item
-level depending on how the initial discount price adjutments were created.
 
-A `before_action` in `Storefront::CheckoutsController` will send customers to Flow's hosted checkout
-if they are checking out in a Flow `Experience`.  After the customer completes the order in hosted
-checkout.  Flow will send an `OrderUpsertedV2` webhook with a `#submitted_at` value.  The `Workarea::Order`
-will be updated and marked as placed.
+A new pricing calculator is added, `FlowLocalizationCalculator` and
+appended to the END of the pricing calculators array; it is important
+that if a build adds custom calculators that the
+`FlowLocalizationCalculator` is last.  This calculator sends the order
+to flow and updates the `Order::Item` and `Shipping` `#price_adjutments`
+with localized prices and updated base prices.  Because of the way
+discounting is passed to flow, discounts are displaying as a generic
+Discount adjustment, instead of an adjustment for each discount.
+Display will still happen at the order or item level depending on how
+the initial discount price adjutments were created.
 
-When `Fulfillment::Item`s are shipped or cancaled in Workarea, workers will update Flow with
-`ShippingNotifications` or `FulfillmentCancellations`
+A `before_action` in `Storefront::CheckoutsController` will send
+customers to Flow's hosted checkout if they are checking out in a Flow
+`Experience`.  After the customer completes the order in hosted
+checkout.  Flow will send an `OrderUpsertedV2` webhook with a
+`#submitted_at` value.  The `Workarea::Order` will be updated and marked
+as placed.
+
+When `Fulfillment::Item`s are shipped or cancaled in Workarea, workers
+will update Flow with `ShippingNotifications` or
+`FulfillmentCancellations`.
 
 ### Session
-A piece of middleware sits in front of `Rack::Cache` that will upsert a `Session` in Flow if the
-`_f60_session` cookie is blank, passing the `request.remote_ip` and `HTTP_GEOIP_CITY_COUNTRY_CODE3` from
-Nginx.  If the `_f60_session` cookie is present and the `flow_experience` cookie isn't a request will
-be made to get the session from the Flow API.  If the API request 404s a new session will be created
-and the `_f60_session` cookie will be updated.  It updates the Http Vary header to include
-`X-Flow-Experience` and stores the current `Experience` in the `flow_experience` cookie as JSON.
-If a user updates their country via the `country_picker.js` the
-`flow_experience` cookie is updated in the `onSessionUpdate` in javaascript.
+
+A piece of middleware sits in front of `Rack::Cache` that will upsert a
+`Session` in Flow if the `_f60_session` cookie is blank, passing the
+`request.remote_ip` and `HTTP_GEOIP_CITY_COUNTRY_CODE3` from Nginx.  If
+the `_f60_session` cookie is present and the `flow_experience` cookie
+isn't a request will be made to get the session from the Flow API.  If
+the API request 404s, a new session will be created and the
+`_f60_session` cookie will be updated.  It updates HTTP's `Vary` header
+to include `X-Flow-Experience` and stores the current `Experience` in
+the `flow_experience` cookie as JSON.  If a user updates their country
+via the `country_picker.js`, the `flow_experience` cookie is updated in
+the `onSessionUpdate` in javascript.
 
 ### Caching
-Cache keys are decorated to include the current `Experience` key.  The Http Vary header
-is adjusted to include `X-Flow-Experience`  The current country ISO-3166-3 code is added
-to the `locale` as added measure agaisnt browser caching and the etag is updated to include
-the `Experience` key
+
+Cache keys are decorated to include the current `Experience` key.  The
+Http Vary header is adjusted to include `X-Flow-Experience`  The current
+country ISO-3166-3 code is added to the `locale` as an added measure
+agaisnt browser caching and the etag is updated to include the
+`Experience` key.
 
 ## Client Considerations
 
-It's assumed that Flow will be the payment processor for foreign orders, and that Flow will `purchase`
-those funds.
-
-3PL(Third Party Logistics) Will need to discussed between the client Flow for foreign orders.
+It's assumed that Flow will be the payment processor for foreign orders,
+and that Flow will `purchase` those funds. 3PL(Third Party Logistics)
+will need to be discussed between the client and Flow for foreign orders.
 
 ## Incompatibilities and Gotchas
-Workarea Flow and Workarea Segmentation both decorate `Workarea::Pricing::Sku#find_price` in incompatible ways.
-If using both, you'll need to manually merge the logic of both implmentations in your build.
 
-If using both Flow Io and Gift Cards, Flow Io should appear after Gift cards in your Gemfile.
+When using this plugin with Gift Cards, make sure `flow_io` appears
+after `gift_cards` in your Gemfile, like so:
 
-Workarea Platform Documentation
---------------------------------------------------------------------------------
+```ruby
+gem 'workarea-gift_cards'
+gem 'workarea-flow_io'
+```
 
-See [http://developer.weblinc.com](http://developer.weblinc.com) for Workarea platform documentation.
+## Contributing
 
-Copyright & Licensing
---------------------------------------------------------------------------------
+Do you have a feature request, documentation update, bug report, or any
+kind of feedback about this plugin? [Create a new issue](https://github.com/workarea-commerce/workarea-flow-io/issues/new/choose)
+and tell us all about it!
 
-Copyright WebLinc 2018. All rights reserved.
+If you have some code you'd like to contribute to `Workarea::FlowIo`,
+make sure tests pass locally by running:
 
-For licensing, contact sales@workarea.com.
+```bash
+rails test                        # runs tests local to the plugin
+rails app:workarea:test:decorated # runs decorated tests
+```
+
+Then, fork this repo and submit a pull request!
+
+## License
+
+`Workarea::FlowIo` is released under the [Business Software License](LICENSE)

--- a/app/models/workarea/flow_io/webhook/shared_secret.rb
+++ b/app/models/workarea/flow_io/webhook/shared_secret.rb
@@ -1,0 +1,12 @@
+module Workarea
+  module FlowIo
+    class Webhook
+      class SharedSecret
+        include ApplicationDocument
+        include UrlToken
+
+        validates :token, presence: true
+      end
+    end
+  end
+end

--- a/lib/tasks/flow_io.rake
+++ b/lib/tasks/flow_io.rake
@@ -34,18 +34,13 @@ namespace :workarea do
 
     desc 'create webhooks'
     task create_webhooks: :environment do
-      puts "Creating webhooks..."
-      unless Workarea::FlowIo.webhook_shared_secret.present?
-        warn <<~eos
-          **************************************************
-          ⛔️ Webhooks require flow_io.webhook_shared_secret to be set in your credentials/secrets
-          **************************************************
-        eos
-        next
-      end
-
+      puts "Creating webhook shared secret..."
       client = Workarea::FlowIo.client
+      secret = Workarea::FlowIo::Webhook::SharedSecret.first_or_create!
       organization_id = Workarea::FlowIo.organization_id
+      client.webhook_settings.put(organization_id, secret: secret.token)
+
+      puts "Creating webhooks..."
       host = Workarea.config.host
 
       webhook_url = Workarea::Storefront::Engine

--- a/lib/workarea/flow_io.rb
+++ b/lib/workarea/flow_io.rb
@@ -52,7 +52,7 @@ module Workarea
     end
 
     def self.webhook_shared_secret
-       credentials[:webhook_shared_secret]
+      Workarea::FlowIo::Webhook::SharedSecret.first.try(:token)
     end
 
     # Conditionally use the real gateway when secrets are present.

--- a/lib/workarea/flow_io/bogus_client.rb
+++ b/lib/workarea/flow_io/bogus_client.rb
@@ -10,6 +10,8 @@ module Workarea
       require 'workarea/flow_io/bogus_client/organizations'
       require 'workarea/flow_io/bogus_client/sessions'
       require 'workarea/flow_io/bogus_client/shipping_notifications'
+      require 'workarea/flow_io/bogus_client/webhooks'
+      require 'workarea/flow_io/bogus_client/webhook_settings'
 
       thread_cattr_accessor :requests, :store_requests
 

--- a/lib/workarea/flow_io/bogus_client/webhook_settings.rb
+++ b/lib/workarea/flow_io/bogus_client/webhook_settings.rb
@@ -1,0 +1,11 @@
+module Workarea
+  module FlowIo
+    class BogusClient
+      class WebhookSettings
+        def put(org_id, secret:)
+          puts 'WARNING: Bogus Client in use. Your settings will not go to Flow'
+        end
+      end
+    end
+  end
+end

--- a/lib/workarea/flow_io/bogus_client/webhooks.rb
+++ b/lib/workarea/flow_io/bogus_client/webhooks.rb
@@ -1,0 +1,11 @@
+module Workarea
+  module FlowIo
+    class BogusClient
+      class Webhooks
+        def post(org_id, form)
+          puts 'WARNING: Bogus Client in use. Your webhooks were not created.'
+        end
+      end
+    end
+  end
+end

--- a/test/integration/workarea/storefront/flow_io_webhooks/order_integration_test.rb
+++ b/test/integration/workarea/storefront/flow_io_webhooks/order_integration_test.rb
@@ -7,6 +7,8 @@ module Workarea
         include Workarea::FlowIo::WebhookIntegrationTest
         include Workarea::FlowIo::FlowFixtures
 
+        setup :setup_shared_secret
+
         def test_order_update
           product = create_product(variants: [{ sku: '386555310-9', regular: 5.00 }])
           product_2 = create_product(variants: [{ sku: '332477498-5', regular: 5.00 }])
@@ -737,6 +739,10 @@ module Workarea
 
         def order_upserted
           canadian_webhook_payload.to_json
+        end
+
+        def setup_shared_secret
+          FlowIo::Webhook::SharedSecret.first_or_create!
         end
       end
     end

--- a/test/support/webhook_integration_test.rb
+++ b/test/support/webhook_integration_test.rb
@@ -33,7 +33,10 @@ module Workarea
         end
 
         def webhook_shared_secret
-          Workarea::FlowIo.webhook_shared_secret
+          @webhook_shared_secret ||= begin
+            secret = Workarea::FlowIo::Webhook::SharedSecret.first_or_create!
+            secret.token
+          end
         end
     end
   end


### PR DESCRIPTION
The webhook shared secret is now generated by the Workarea application
automatically as part of the install procedure for the plugin, right
before webhooks are created on Flow's side. Update README to include
information on new configuration settings, remove notes on the webhook
secret, and reformat the docs so they're friendly to total newbies as
well as an old Linuxbeard. Fix some typos and grammar in the README as
well. This also adds the `LICENSE` file to the repository for future open
source goodness.