### PR TITLE
Download Full CSV File from SFTP

### DIFF
--- a/test/workers/workarea/flow_io/fetch_import_test.rb
+++ b/test/workers/workarea/flow_io/fetch_import_test.rb
@@ -9,19 +9,15 @@ module Workarea
         fixture = FlowIo::Engine.root.join(
           'test', 'fixtures', 'files', 'example.csv'
         )
-        file = mock('Net::SFTP::Operations::File')
         path = Pathname.new('flow').join('from-flow', 'export')
         dir = mock('Net::SFTP::Operations::Dir')
         sftp = mock('Net::SFTP::Session')
-        handler = mock('Net::SFTP::Operations::FileHandler')
         entry = mock('Net::SFTP::Operations::Entry')
 
         entry.expects(:name).at_least_once.returns(fixture.basename.to_s)
-        file.expects(:gets).returns(fixture.read)
-        dir.expects(:glob).twice.with(path.to_s, '*.csv').yields(entry)
-        handler.expects(:open).with(path.join(fixture.basename).to_s).yields(file)
+        dir.expects(:glob).at_least_once.with(path.to_s, '*.csv').yields(entry)
         sftp.expects(:dir).at_least_once.returns(dir)
-        sftp.expects(:file).returns(handler)
+        sftp.expects(:download!).at_least_once.returns(fixture.read)
         FlowIo.expects(:credentials).at_least_once.returns(
           ftp_username: username,
           ftp_password: password
@@ -36,36 +32,6 @@ module Workarea
           FetchImport.new.perform
         end
         assert_equal(fixture.basename.to_s, Import.all.first.name)
-        assert_no_difference -> { Import.count } do
-          FetchImport.new.perform
-        end
-      end
-
-      def test_prevent_importing_the_same_csv_twice
-        username = 'admin'
-        password = 'hunter2'
-        fixture = FlowIo::Engine.root.join(
-          'test', 'fixtures', 'files', 'example.csv'
-        )
-        path = Pathname.new('flow').join('from-flow', 'export')
-        dir = mock('Net::SFTP::Operations::Dir')
-        sftp = mock('Net::SFTP::Session')
-        entry = mock('Net::SFTP::Operations::Entry')
-
-        entry.expects(:name).at_least_once.returns(fixture.basename.to_s)
-        dir.expects(:glob).with(path.to_s, '*.csv').yields(entry)
-        sftp.expects(:dir).at_least_once.returns(dir)
-        FlowIo.expects(:credentials).at_least_once.returns(
-          ftp_username: username,
-          ftp_password: password
-        )
-        Net::SFTP.expects(:start).with(
-          FlowIo::FTP_HOST,
-          username,
-          password: password
-        ).yields(sftp)
-
-        Import.create!(name: fixture.basename, file: fixture.open)
         assert_no_difference -> { Import.count } do
           FetchImport.new.perform
         end


### PR DESCRIPTION
Apparently, `.gets` only grabs the first line of the file. Using
`sftp.download!` will output the whole contents of a file to String,
which is what we want here, and I couldn't figure out how to make it
stream `.gets` to more than one line.