### PR TITLE
Fix Package View Model Method Access

### DIFF
--- a/app/view_models/workarea/storefront/product_templates/package_view_model.decorator
+++ b/app/view_models/workarea/storefront/product_templates/package_view_model.decorator
@@ -1,14 +1,13 @@
 module Workarea
-  if Plugin.installed?("Workarea::PackageProducts")
+  if Plugin.installed?(:package_products)
     decorate Storefront::ProductTemplates::PackageViewModel, with: :flow_io do
-      private
-        def pricing
-          super.tap do |pricing_collection|
-            if options[:flow_experience]
-              pricing_collection.flow_experience = options[:flow_experience]
-            end
+      def pricing
+        super.tap do |pricing_collection|
+          if options[:flow_experience]
+            pricing_collection.flow_experience = options[:flow_experience]
           end
         end
+      end
     end
   end
 end

--- a/test/view_models/workarea/storefront/package_view_model_test.decorator
+++ b/test/view_models/workarea/storefront/package_view_model_test.decorator
@@ -1,11 +1,13 @@
 module Workarea
-  decorate Storefront::PackageViewModelTest, with: :flow_io do
-    decorated { setup :stub_flow_worker }
+  if Plugin.installed?(:package_products)
+    decorate Storefront::PackageViewModelTest, with: :flow_io do
+      decorated { setup :stub_flow_worker }
 
-    private
+      private
 
-      def stub_flow_worker
-        Workarea::FlowIo::ShippingNotifications.any_instance.stubs(:perform).returns(stub_everything)
-      end
+        def stub_flow_worker
+          Workarea::FlowIo::ShippingNotifications.any_instance.stubs(:perform).returns(stub_everything)
+        end
+    end
   end
 end


### PR DESCRIPTION
The `#pricing` method on PackageViewModel is a public method, so remove
the `private` distinction here so Flow will work with package products.