### PR TITLE
Fix Export Issues and Remove CSV After Consuming

### DIFF
--- a/app/services/workarea/flow_io/item.rb
+++ b/app/services/workarea/flow_io/item.rb
@@ -90,10 +90,12 @@ module Workarea
       def variant_specific_images
         @variant_specific_images ||=
           begin
-            sku_options = variant.details.values.flat_map { |options| options.map(&:optionize) }
+            sku_options = variant.details.values.flat_map do |options|
+              options.compact.map(&:optionize)
+            end
 
             product.images.select do |image|
-              sku_options.include?(image.option.optionize)
+              sku_options.include?(image.option&.optionize)
             end
           end
       end

--- a/app/view_models/workarea/storefront/product_view_model.decorator
+++ b/app/view_models/workarea/storefront/product_view_model.decorator
@@ -11,5 +11,10 @@ module Workarea
         end
       end
     end
+
+    def one_price?
+      return false if original_min_price.nil?
+      super
+    end
   end
 end

--- a/app/workers/workarea/flow_io/fetch_import.rb
+++ b/app/workers/workarea/flow_io/fetch_import.rb
@@ -14,10 +14,11 @@ module Workarea
 
         Net::SFTP.start(FlowIo::FTP_HOST, username, password: password) do |sftp|
           sftp.dir.glob(path.to_s, '*.csv') do |entry|
+            filepath = path.join(entry.name).to_s
+
             Import.find_or_create_by!(name: entry.name) do |import|
               import.file = Tempfile.new(entry.name).tap do |tmp|
                 begin
-                  filepath = path.join(entry.name).to_s
                   csv = sftp.download!(filepath)
 
                   tmp.write(csv)
@@ -26,6 +27,8 @@ module Workarea
                 end
               end
             end
+
+            sftp.remove!(filepath)
           end
         end
       end

--- a/test/models/workarea/flow_io/imported_item_test.rb
+++ b/test/models/workarea/flow_io/imported_item_test.rb
@@ -5,7 +5,7 @@ module Workarea
     class ImportedItemTest < TestCase
       def test_import_from_params
         assert_difference -> { Pricing::Sku.count } do
-          imported = ImportedItem.process(
+          ImportedItem.process(
             {
               'experience[key]' => 'canada',
               'item[number]' => '607508142-9',
@@ -38,11 +38,55 @@ module Workarea
             },
             FlowIo.client.experiences.get(FlowIo.organization_id)
           )
+
           sku = Pricing::Sku.find('607508142-9')
           local_item = sku.flow_io_local_items.last
           regular = local_item.prices.first.regular
 
           assert_equal(20.to_m('CAD'), regular.price)
+        end
+      end
+
+      def test_import_with_blank_amount_or_currency
+        assert_difference -> { Pricing::Sku.count } do
+          ImportedItem.process(
+            {
+              'experience[key]' => 'canada',
+              'item[number]' => '607508142-9',
+              'prices[item][amount]' => '20.0',
+              'prices[item][base][amount]' => '14.6',
+              'prices[item][base][currency]' => 'USD',
+              'prices[item][base][label]' => 'US$14.60',
+              'prices[item][currency]' => 'CAD',
+              'prices[item][includes][key]' => 'none',
+              'prices[item][includes][label]' => 'HST and duty not included',
+              'prices[item][label]' => 'CA$20.00',
+              'prices[price_attributes][msrp][amount]' => '30.0',
+              'prices[price_attributes][msrp][base][amount]' => '21.9',
+              'prices[price_attributes][msrp][base][currency]' => 'USD',
+              'prices[price_attributes][msrp][base][label]' => 'US$21.90',
+              'prices[price_attributes][msrp][currency]' => 'CAD',
+              'prices[price_attributes][msrp][label]' => 'CA$30.00',
+              'prices[price_attributes][regular_price][amount]' => '',
+              'prices[price_attributes][regular_price][base][amount]' => '14.6',
+              'prices[price_attributes][regular_price][base][currency]' => 'USD',
+              'prices[price_attributes][regular_price][base][label]' => 'US$14.60',
+              'prices[price_attributes][regular_price][currency]' => '',
+              'prices[price_attributes][regular_price][label]' => 'CA$20.00',
+              'prices[price_attributes][sale_price][amount]' => '10.0',
+              'prices[price_attributes][sale_price][base][amount]' => '7.3',
+              'prices[price_attributes][sale_price][base][currency]' => 'USD',
+              'prices[price_attributes][sale_price][base][label]' => 'US$7.30',
+              'prices[price_attributes][sale_price][currency]' => 'CAD',
+              'prices[price_attributes][sale_price][label]' => 'CA$10.00',
+            },
+            FlowIo.client.experiences.get(FlowIo.organization_id)
+          )
+
+          sku = Pricing::Sku.find('607508142-9')
+          local_item = sku.flow_io_local_items.last
+
+          assert_empty(local_item.prices)
         end
       end
     end

--- a/test/workers/workarea/flow_io/fetch_import_test.rb
+++ b/test/workers/workarea/flow_io/fetch_import_test.rb
@@ -18,6 +18,7 @@ module Workarea
         dir.expects(:glob).at_least_once.with(path.to_s, '*.csv').yields(entry)
         sftp.expects(:dir).at_least_once.returns(dir)
         sftp.expects(:download!).at_least_once.returns(fixture.read)
+        sftp.expects(:remove!).at_least_once
         FlowIo.expects(:credentials).at_least_once.returns(
           ftp_username: username,
           ftp_password: password


### PR DESCRIPTION
Remove CSV from the server after it has been consumed, remove
an unnecessary validation, and add a mock for `sftp.remove!` so the test
will pass. This also solves an issue with the flow exporter after
items have been imported via CSV, sets the country & currency
properly on an experience, and defends against missing prices in the
import for whatever reason.

No changelog.

FLOW-6