### PR TITLE
Fix Base Item Price In Line Items

### DIFF
--- a/app/services/workarea/flow_io/line_item_form.rb
+++ b/app/services/workarea/flow_io/line_item_form.rb
@@ -14,7 +14,7 @@ module Workarea
 
       def price
         ::Io::Flow::V0::Models::Money.new(
-          amount: base_item_price.cents,
+          amount: base_item_price.to_f,
           currency: base_item_price.currency.to_s
         )
       end

--- a/test/services/workarea/flow_io/line_item_form_test.rb
+++ b/test/services/workarea/flow_io/line_item_form_test.rb
@@ -25,7 +25,7 @@ module Workarea
         )
         discounts = item.to_h[:discounts]
 
-        assert_equal(11000, item.price.amount)
+        assert_equal(110.0, item.price.amount)
         assert_equal(order.experience.currency, item.price.currency)
         refute_empty(discounts.discounts)
       end

--- a/test/services/workarea/flow_io/order_put_form_test.rb
+++ b/test/services/workarea/flow_io/order_put_form_test.rb
@@ -21,7 +21,7 @@ module Workarea
 
         assert_equal(order_put_form.customer.name.first, user.first_name)
         assert_equal(order_put_form.customer.name.last, user.last_name)
-        assert_equal(11000, line_item_form.price.amount)
+        assert_equal(110.0, line_item_form.price.amount)
         assert_equal('CAD', line_item_form.price.currency)
       end
 


### PR DESCRIPTION
Passing `cents` into the price amount for a line item caused prices on
Flow's side to be way higher than they should be. This should have been
a floating point value equal to the price of the item. It has been
changed as such and should fix the issues experienced in QA for checking
out Flow items.