### PR TITLE
Use Unit Price Instead of Total in LineItemForm

### DIFF
--- a/app/services/workarea/flow_io/line_item_form.rb
+++ b/app/services/workarea/flow_io/line_item_form.rb
@@ -47,7 +47,9 @@ module Workarea
             .flow_price_adjustments
             .adjusting('item')
             .reject(&:discount?)
+            .map(&:unit)
             .sum
+            .to_m
         end
 
         def discounts_form

--- a/app/views/workarea/admin/pricing_skus/flow.html.haml
+++ b/app/views/workarea/admin/pricing_skus/flow.html.haml
@@ -56,5 +56,5 @@
           %tr
             %td= localized_price.regular.price.format
             %td= localized_price.regular.base_currency.price.format
-            %td= localized_price.sale&.price.format
-            %td= localized_price.sale&.base_currency&.price.format
+            %td= localized_price.sale&.price&.format
+            %td= localized_price.sale&.base_currency&.price&.format


### PR DESCRIPTION
In the `FlowIo::LineItemForm` we were originally using the amount that
was saved into price adjustments, which includes the quantity
multiplier. The result was that cart item prices were not accurate. To
remedy this, Workarea now uses the unit price for the item.