### PR TITLE
Fix Timeouts On Category Pages

### DIFF
--- a/app/models/workarea/flow_io/localized_price.rb
+++ b/app/models/workarea/flow_io/localized_price.rb
@@ -19,7 +19,6 @@ module Workarea
        #
        def to_price
          Workarea::Pricing::Price.new(
-           sku: self.local_item.sku.clone, # clone the sku so this price isn't added to #prices on real record
            min_quantity: min_quantity,
            regular: regular.price,
            sale: sale&.price


### PR DESCRIPTION
Remove `sku:` setting from the call to `#to_price` to ensure category
pages will render on time. This doesn't seem to have an effect down the
line on checkouts, and I don't think its presence is necessary.

FLOW-17